### PR TITLE
🔥 Archive logs from deleted ProcessModels

### DIFF
--- a/metrics.contracts/package.json
+++ b/metrics.contracts/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"
   },

--- a/metrics.contracts/package.json
+++ b/metrics.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics_api_contracts",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Contains the contracts for the ProcessEngine's Metrics API",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/metrics.contracts/package.json
+++ b/metrics.contracts/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"
   },

--- a/metrics.contracts/package.json
+++ b/metrics.contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics_api_contracts",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.1",
   "description": "Contains the contracts for the ProcessEngine's Metrics API",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/metrics.contracts/src/imetrics_api.ts
+++ b/metrics.contracts/src/imetrics_api.ts
@@ -174,4 +174,15 @@ export interface IMetricsApi {
     tokenPayload: any,
     timestamp: moment.Moment,
   ): Promise<void>;
+
+  /**
+   * Places all metrics for the given ProcessModel into the "archive" folder.
+   * Essentially, this is pretty much like "deleting" the metrics, as they will no longer be available.
+   *
+   * However, since metrics are somewhat sensitive, they will not be deleted, but archived.
+   *
+   * @param identity       The identity of the requesting user.
+   * @param processModelId The ID of the ProcessModel whose metrics are to be archived.
+   */
+  archiveProcessModelMetrics(identity: IIdentity, processModelId: string): Promise<void>;
 }

--- a/metrics.contracts/src/imetrics_repository.ts
+++ b/metrics.contracts/src/imetrics_repository.ts
@@ -77,4 +77,15 @@ export interface IMetricsRepository {
     timestamp: moment.Moment,
     error?: Error,
   ): Promise<void>;
+
+  /**
+   * Places all metrics for the given ProcessModel into the "archive" folder.
+   * Essentially, this is pretty much like "deleting" the metrics, as they will no longer be available.
+   *
+   * However, since metrics are somewhat sensitive, they will not be deleted, but archived.
+   *
+   * @param identity       The identity of the requesting user.
+   * @param processModelId The ID of the ProcessModel whose metrics are to be archived.
+   */
+  archiveProcessModelMetrics(processModelId: string): Promise<void>;
 }

--- a/metrics.contracts/src/imetrics_repository_config.ts
+++ b/metrics.contracts/src/imetrics_repository_config.ts
@@ -1,0 +1,5 @@
+/* eslint-disable @typescript-eslint/camelcase */
+export interface IMetricsRepositoryConfig {
+  output_path: string;
+  archive_path?: string; // If not provided "<output_path>/archive" will be used
+}

--- a/metrics.contracts/src/index.ts
+++ b/metrics.contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from './imetrics_api';
+export * from './imetrics_repository_config';
 export * from './imetrics_repository';
 export * from './metric_measurement_point';
 export * from './metric';

--- a/metrics.repository.file_system/package.json
+++ b/metrics.repository.file_system/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/metrics_api_contracts": "2.0.0",
+    "@process-engine/metrics_api_contracts": "feature~implement_log_archival",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/metrics.repository.file_system/package.json
+++ b/metrics.repository.file_system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics.repository.file_system",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Contains the file-system repository for the Metrics API. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/metrics.repository.file_system/package.json
+++ b/metrics.repository.file_system/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/metrics.repository.file_system/package.json
+++ b/metrics.repository.file_system/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/metrics.repository.file_system/package.json
+++ b/metrics.repository.file_system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics.repository.file_system",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.1",
   "description": "Contains the file-system repository for the Metrics API. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/process-engine/metrics.repository.file_system#readme",
   "dependencies": {
     "@essential-projects/errors_ts": "^1.5.0",
-    "@process-engine/metrics_api_contracts": "feature~implement_log_archival",
+    "@process-engine/metrics_api_contracts": "3.0.0-alpha.1",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/metrics.repository.file_system/src/adapter/file_system_adapter.ts
+++ b/metrics.repository.file_system/src/adapter/file_system_adapter.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as moment from 'moment';
 import * as mkdirp from 'mkdirp';
 import * as path from 'path';
 
@@ -74,7 +75,25 @@ export function readAndParseFile(filePath: string): Array<Metric> {
     return isNotEmpty && isNotAComment;
   });
 
-  const metrics = filteredEntries.map(parseMetric);
+  const convertedMetrics = filteredEntries.map(parseMetric);
+  const metrics = convertedMetrics.filter((entry): boolean => entry !== undefined);
 
   return metrics;
+}
+
+export async function moveMetricFileToArchive(archiveFolderPath, fileToMove): Promise<void> {
+
+  const timeTagForArchivedFile = moment()
+    .toISOString()
+    .replace(/:/g, '_')
+    .replace(/\./g, '_');
+
+  const sourceFileInfo = path.parse(fileToMove);
+
+  const archivedFileName = `${sourceFileInfo.name}-${timeTagForArchivedFile}${sourceFileInfo.ext}`;
+  const archivedFilePath = path.resolve(archiveFolderPath, archivedFileName);
+
+  await ensureDirectoryExists(archivedFilePath);
+
+  fs.renameSync(fileToMove, archivedFilePath);
 }

--- a/metrics.repository.file_system/src/adapter/parser/flow_node_metric_parser.ts
+++ b/metrics.repository.file_system/src/adapter/parser/flow_node_metric_parser.ts
@@ -6,13 +6,17 @@ import * as ErrorSerializer from '../error_serializer';
 
 export function parseFlowNodeInstanceMetric(metricData: Array<string>): Metric {
 
-  const isV2 = metricData[0].endsWith('_V2');
+  const isV1 = metricData[0] === 'FlowNodeInstance';
+  const isV2 = metricData[0] === 'FlowNodeInstance_V2';
 
+  if (isV1) {
+    return parseAsV1(metricData);
+  }
   if (isV2) {
     return parseAsV2(metricData);
   }
 
-  return parseAsV1(metricData);
+  return undefined;
 }
 
 /**

--- a/metrics.repository.file_system/src/adapter/parser/process_model_metric_parser.ts
+++ b/metrics.repository.file_system/src/adapter/parser/process_model_metric_parser.ts
@@ -6,13 +6,17 @@ import * as ErrorSerializer from '../error_serializer';
 
 export function parseProcessModelMetric(metricData: Array<string>): Metric {
 
-  const isV2 = metricData[0].endsWith('_V2');
+  const isV1 = metricData[0] === 'ProcessModel';
+  const isV2 = metricData[0] === 'ProcessModel_V2';
 
+  if (isV1) {
+    return parseAsV1(metricData);
+  }
   if (isV2) {
     return parseAsV2(metricData);
   }
 
-  return parseAsV1(metricData);
+  return undefined;
 }
 
 /**

--- a/metrics.repository.file_system/src/metrics_repository.ts
+++ b/metrics.repository.file_system/src/metrics_repository.ts
@@ -2,7 +2,10 @@ import * as moment from 'moment';
 import * as path from 'path';
 
 import {
-  IMetricsRepository, Metric, MetricMeasurementPoint,
+  IMetricsRepository,
+  IMetricsRepositoryConfig,
+  Metric,
+  MetricMeasurementPoint,
 } from '@process-engine/metrics_api_contracts';
 
 import * as ErrorSerializer from './adapter/error_serializer';
@@ -10,7 +13,7 @@ import * as FileSystemAdapter from './adapter/file_system_adapter';
 
 export class MetricsRepository implements IMetricsRepository {
 
-  public config: any;
+  public config: IMetricsRepositoryConfig;
 
   public async readMetricsForProcessModel(processModelId: string): Promise<Array<Metric>> {
 

--- a/metrics.service/package.json
+++ b/metrics.service/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "2.2.0-beta.4",
+    "@process-engine/ci_tools": "^2.2.0",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/metrics.service/package.json
+++ b/metrics.service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics_api_core",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.1",
   "description": "Contains all the core components for the metrics api. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/metrics_api_core#readme",
   "dependencies": {
-    "@process-engine/metrics_api_contracts": "feature~implement_log_archival",
+    "@process-engine/metrics_api_contracts": "3.0.0-alpha.1",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/metrics.service/package.json
+++ b/metrics.service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics_api_core",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Contains all the core components for the metrics api. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/metrics.service/package.json
+++ b/metrics.service/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/metrics_api_core#readme",
   "dependencies": {
-    "@process-engine/metrics_api_contracts": "2.0.0",
+    "@process-engine/metrics_api_contracts": "feature~implement_log_archival",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/metrics.service/package.json
+++ b/metrics.service/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@essential-projects/eslint-config": "^1.0.0",
-    "@process-engine/ci_tools": "^2.0.0",
+    "@process-engine/ci_tools": "2.2.0-beta.4",
     "@types/node": "^10.12.2",
     "eslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/metrics.service/src/metrics_api_service.ts
+++ b/metrics.service/src/metrics_api_service.ts
@@ -169,4 +169,10 @@ export class MetricsApiService implements IMetricsApi {
     );
   }
 
+  public async archiveProcessModelMetrics(identity: IIdentity, processModelId: string): Promise<void> {
+    await this
+      .metricsRepository
+      .archiveProcessModelMetrics(processModelId);
+  }
+
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics_api",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Changes

1. Implement `archiveProcessModelMetrics` functionality for each layer
2. Add `IMetricsRepositoryConfig` interface for use with the `MetricRepository`'s config
3. Robustify metric parsers to prevent crashes during read operations

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/373

PR: #1

## How to test the changes

- Create some metrics for a ProcessModel
- Call `archiveProcessModelMetrics` with that ProcessModel's ID
- See that the file is moved to the `archive` folder
    - Note: If you haven't specified `archive_path` in your repository-config, then the file will be moved to `<output_path>/archive`